### PR TITLE
Added an R interface to ECharts into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A curated list of awesome data visualizations frameworks, libraries and software
 - [rgl](https://cran.r-project.org/web/packages/rgl/index.html) - 3D Visualization Using OpenGL
 - [shiny](http://shiny.rstudio.com) - Framework for creating interactive applications/visualisations
 - [visNetwork](http://dataknowledge.github.io/visNetwork/) - Interactive network visualisations
+- [ECharts2Shiny](https://github.com/XD-DENG/ECharts2Shiny) - Ebmed interactive charts built by ECharts into R Shiny applications
 
 ## Ruby tools
 - [Chartkick](https://github.com/ankane/chartkick) - Create charts with one line of Ruby.


### PR DESCRIPTION
This package can help embed the interactive charts from ECharts (a javascript chart library) into R Shiny applications.

It's already published on CRAN (https://cran.r-project.org/web/packages/ECharts2Shiny), the official repository of R.