### PR TITLE
Add circos

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Tools that are not tied to a particular platform or language.
 - [Lightning](http://lightning-viz.org/) - A data-visualization server providing API-based access to reproducible, web-based, interactive visualizations.
 - [RAW](http://raw.densitydesign.org/) - Create web visualizations from CSV or Excel files.
 - [Spark](https://github.com/holman/spark) - Sparklines for the shell. It have several [implementations in different languages](https://github.com/holman/spark/wiki/Alternative-Implementations).
-- [Circos](http://circos.ca) - Visualizes data in a circular layout — this makes Circos ideal for exploring relationships between objects or positions. free software, written in Perl and licensed under GPL. [Mirror on github](http://github.com/node/circos).
+- [Circos](http://circos.ca) - Visualizes data in a circular layout — this makes Circos ideal for exploring relationships between objects or positions. free software, written in Perl and licensed under GPL. [Mirror on github](https://github.com/node/circos).
 
 # Resources
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Tools that are not tied to a particular platform or language.
 - [Lightning](http://lightning-viz.org/) - A data-visualization server providing API-based access to reproducible, web-based, interactive visualizations.
 - [RAW](http://raw.densitydesign.org/) - Create web visualizations from CSV or Excel files.
 - [Spark](https://github.com/holman/spark) - Sparklines for the shell. It have several [implementations in different languages](https://github.com/holman/spark/wiki/Alternative-Implementations).
-
+- [Circos](http://circos.ca) - Visualizes data in a circular layout — this makes Circos ideal for exploring relationships between objects or positions. free software, written in Perl and licensed under GPL. [Mirror on github](http://github.com/node/circos).
 
 # Resources
 


### PR DESCRIPTION
A circle style layout open source data visualization tools by Perl under GPL .

"Although originally designed for visualizing genomic data, it can create figures from data in any field—from genomics to visualizing migration to mathematical art. If you have data that describes relationships or multi-layered annotations of one or more scales, Circos is for you. "

I have used this for several years. It's useful and cool and ... circluar :)  We can visit http://circos.ca/images/published/ to see more published example .

Hope collected in this awesome list. 