### PR TITLE
Add CBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Tools that are not tied to a particular platform or language.
 - [RAW](http://rawgraphs.io) - Create web visualizations from CSV or Excel files.
 - [Spark](https://github.com/holman/spark) - Sparklines for the shell. It have several [implementations in different languages](https://github.com/holman/spark/wiki/Alternative-Implementations).
 - [Superset](https://github.com/airbnb/superset) - A data exploration platform designed to be visual, intuitive, and interactive
+- [CBoard](https://github.com/yzhang921/CBoard)- A java built, easy to use, self-service open BI reporting and BI dashboard platform.
 
 # Resources
 


### PR DESCRIPTION
CBoard is a java built, easy to use, self-service open BI reporting and BI dashboard platform. It's been used in many enterprises for OLAP analysis, data visualization.   
It has many same features with Superset.  The main difference is that it built with java. So it more suitable for companies that only master in java for maintenance reason.  
User can write its own data source adapter besides all relational database, Elasticsearch, Kylin, Solr that have already been built in CBoard. 
Hope it can help more peoples and companies.