### PR TITLE
add datavis blogs from d3 slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,25 @@ Tools that are not tied to a particular platform or language.
 - [Visualizing](https://twitter.com/VisualizingOrg)
 
 ## Websites
-- [FlowingData](http://flowingdata.com/)
-- [Gnuplotting](http://www.gnuplotting.org/) - [Gnuplot](http://www.gnuplot.info/) tutorials
-- [Information is Beautiful](http://www.informationisbeautiful.net/)
-- [The Pudding](https://pudding.cool/)
-- [The Data Visualization Catalogue](http://www.datavizcatalogue.com/) - A collection of data visualization methods, with pros and cons.
-- [Visual Complexity](http://www.visualcomplexity.com/vc/) - A site about the visualization of complex networks.
+- [Ann K. Emery](http://annkemery.com/)'s blog  
+- [eagereyes](https://eagereyes.org/)  
+- [EvergreenData](http://stephanieevergreen.com/)  
+- [FlowingData](http://flowingdata.com/)  
+- [Gnuplotting](http://www.gnuplotting.org/) - [Gnuplot](http://www.gnuplot.info/) tutorials  
+- [Information is Beautiful](http://www.informationisbeautiful.net/)  
+- [InfoVis Group @ UBC Computer Science](http://www.cs.ubc.ca/group/infovis/)  
+- [Junk Charts](http://junkcharts.typepad.com/) - Kaiser Fung takes apart why certain datavizes work/don't work
+- [Lisa Rost thinks and discusses about why we dataviz](https://lisacharlotterost.github.io/)  
+- [Makeover Monday](http://www.makeovermonday.co.uk/) blog - [#MakeoverMonday](https://twitter.com/search?q=%23makeovermonday) on twitter  
+- [roadtolarissa](https://roadtolarissa.com/)  
+- [The Data Visualization Catalogue](http://www.datavizcatalogue.com/) - A collection of data visualization methods, with pros and cons.  
+- [the functional art](http://www.thefunctionalart.com/)  
+- [The Open News](https://source.opennews.org/articles/) blog -  Open news has some good dataviz related articles from time to time  
+- [The Pudding](https://pudding.cool/) - [Dataviz Pro-Tips](https://pudding.cool/#pro-tips) 
+- [Truth & Beauty Operations](https://truth-and-beauty.net/) 
+- [University of Washington Interactive Data Lab Papers](http://idl.cs.washington.edu/papers)  
+- [vis4.net](https://www.vis4.net/blog/) - Random thoughts on visualization and data journalism by Gregor Aisch  
+- [Visual Complexity](http://www.visualcomplexity.com/vc/) - A site about the visualization of complex networks.  
 
 
 # Contributing


### PR DESCRIPTION
This PR contributes dataviz blog links shared recently on the d3js slack 😄 

https://d3js.slack.com/archives/C07ET41MG/p1510076712000582

<img width="1041" alt="screen shot 2017-11-08 at 12 29 24 pm" src="https://user-images.githubusercontent.com/2119400/32572847-c97aaa9c-c480-11e7-8aff-e19f6881a7a2.png">
