### PR TITLE
Add DNA Claude Analysis to Other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A curated list of awesome **open-source** data visualizations frameworks, librar
 ## Other tools
 Tools that are not tied to a particular platform or language.
 - [Charted](https://github.com/mikesall/charted) - A charting tool that produces automatic, shareable charts from any data file.
+- [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) - Terminal-style single-page HTML dashboard for personal DNA analysis visualization with color-coded risk levels and interactive navigation.
 - [Gephi](https://github.com/gephi/gephi) - An open-source platform for visualizing and manipulating large graphs
 - [Kepler.gl](https://kepler.gl/) - Geospatial analysis tool for large-scale data sets.
 - [Mermaid](https://github.com/knsv/mermaid) - A tool used to generate diagrams and flowcharts from text in a similar manner as markdown.


### PR DESCRIPTION
## Summary

- Adds [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) to the "Other tools" section
- It is a terminal-style single-page HTML dashboard for personal DNA analysis visualization with green-on-black hacker aesthetic, color-coded risk levels (green/amber/red), and interactive navigation
- Placed in alphabetical order between Charted and Gephi

🤖 Generated with [Claude Code](https://claude.com/claude-code)