### PR TITLE
Add csvtodashboard to Other tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A curated list of awesome **open-source** data visualizations frameworks, librar
 ## Other tools
 Tools that are not tied to a particular platform or language.
 - [Charted](https://github.com/mikesall/charted) - A charting tool that produces automatic, shareable charts from any data file.
+- [csvtodashboard](https://csvtodashboard.com) - Turn a CSV or Excel file into an auto-built dashboard in the browser - client-side, no upload.
 - [Gephi](https://github.com/gephi/gephi) - An open-source platform for visualizing and manipulating large graphs
 - [Kepler.gl](https://kepler.gl/) - Geospatial analysis tool for large-scale data sets.
 - [Mermaid](https://github.com/knsv/mermaid) - A tool used to generate diagrams and flowcharts from text in a similar manner as markdown.


### PR DESCRIPTION
Adds csvtodashboard under **Other tools** (alphabetical slot after Charted) — it turns a CSV/Excel file into an auto-built dashboard, with charts, KPIs and filters, entirely in the browser.

Disclosure: I work on this tool. It is free, requires no signup, and runs 100% client-side (the file never leaves the machine — verifiable in DevTools). Kept the description short and unbiased per the contributing notes; one suggestion, one commit. Happy to adjust the wording or drop the entry if it is not a fit.